### PR TITLE
Выделение категорий с ошибками при формировании подгрупп

### DIFF
--- a/TournamentSoftware/appState/TournamentData.cs
+++ b/TournamentSoftware/appState/TournamentData.cs
@@ -16,6 +16,7 @@ namespace TournamentSoftware
         public static string cellsColor = "#F5F1DA";
         public static SolidColorBrush yellow = new SolidColorBrush(Color.FromRgb(255, 215, 0));
         public static SolidColorBrush white = new SolidColorBrush(Color.FromRgb(255, 255, 255));
+        public static SolidColorBrush orange = new SolidColorBrush(Color.FromRgb(253, 172, 97));
 
         public static Style GetCellStyle()
         {

--- a/TournamentSoftware/sourceCode/Subgrouping.cs
+++ b/TournamentSoftware/sourceCode/Subgrouping.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Media.Effects;
 using static TournamentSoftware.TournamentData;
 
 namespace TournamentSoftware
@@ -359,6 +360,38 @@ namespace TournamentSoftware
             }
         }
 
+        private void RemoveShadowFromCategoryButtons()
+        {
+            categoriesButtons.ForEach(button => {
+                button.Effect = null;
+            });
+        }
+
+        private void AddShadowToCategoryButtonWithErrors(CategoryWrapper category)
+        {
+            string categoryName = category.Name;
+            if (category.Subgroups.Exists(subgroup => subgroup.Errors.Count > 0))
+            {
+                Button btn = categoriesButtons.Find(button => button.Tag.ToString().Equals(categoryName));
+
+                btn.Effect = new DropShadowEffect
+                {
+                    Color = orange.Color,
+                    Opacity = 0.5,
+                    BlurRadius = 10,
+                };
+            }
+        }
+
+        private void AddShadowToCategoryButtonsWithErrors()
+        {
+            List<CategoryWrapper> categories = GetCategoriesFromNomination(selectedNomination);
+            categories.ForEach(category => {
+                AddShadowToCategoryButtonWithErrors(category);
+            });
+        }
+
+
         private void PrepareCategoryForSubgrouping()
         {
             CategoryWrapper category = GetCategoryFromNomination(selectedNomination, selectedCategory);
@@ -406,6 +439,8 @@ namespace TournamentSoftware
                 }
 
                 ShowSubgroups();
+                RemoveShadowFromCategoryButtons();
+                AddShadowToCategoryButtonsWithErrors();
             }
             else
             {

--- a/TournamentSoftware/sourceCode/Subgrouping.cs
+++ b/TournamentSoftware/sourceCode/Subgrouping.cs
@@ -391,7 +391,6 @@ namespace TournamentSoftware
             });
         }
 
-
         private void PrepareCategoryForSubgrouping()
         {
             CategoryWrapper category = GetCategoryFromNomination(selectedNomination, selectedCategory);


### PR DESCRIPTION
Если при формировании подгрупп появляются ошибки, кнопка выделяется оранжевой тенью. 
Если ошибок нет - тень убирается.