### PR TITLE
Исправление бага 97

### DIFF
--- a/TournamentSoftware/AddStageWindow.xaml.cs
+++ b/TournamentSoftware/AddStageWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace TournamentSoftware
             if (fightingSystemsCombobox.SelectedValue.ToString() == "Круговая")
             {
                 if (!int.TryParse(rounds.Text, out int roundsCount))
-                    MessageBox.Show("Введите количество кругов", "Ошибка");
+                    MessageBox.Show("Введено некорректное количество кругов", "Ошибка");
                 else
                 {
                     TournamentGridWindow.roundsCount = roundsCount;


### PR DESCRIPTION
Описание бага подробно представлено [issue 97](https://github.com/Students-of-the-city-of-Kostroma/tournament-project/issues/97)

**Проблема:** Вылетает приложение в окне выбора системы боя при вставке в поле круга символов или пробела

**Решение:** Это было исправлено в [pr 155](https://github.com/Students-of-the-city-of-Kostroma/tournament-project/pull/115), изменил сообщение об ошибке.