### PR TITLE
Исправление бага 78

### DIFF
--- a/TournamentSoftware/MainWindow.xaml.cs
+++ b/TournamentSoftware/MainWindow.xaml.cs
@@ -792,6 +792,13 @@ namespace TournamentSoftware
 
         private void TextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
+            if ((sender as TextBox).Text != "" && !int.TryParse((sender as TextBox).Text, out _))
+            {
+                (sender as TextBox).Text = "";
+                MessageBox.Show("Строка должна содержать только цифры!", "Ошибка");
+                return;
+            }
+
             if ((sender as TextBox).Text == "" || Convert.ToInt32((sender as TextBox).Text) < 1900 || Convert.ToInt32((sender as TextBox).Text) > DateTime.Now.Year - 13)
             {
                 (sender as TextBox).Background = (Brush)new BrushConverter().ConvertFrom("#FFFFDDDB");

--- a/TournamentSoftware/MainWindow.xaml.cs
+++ b/TournamentSoftware/MainWindow.xaml.cs
@@ -792,12 +792,8 @@ namespace TournamentSoftware
 
         private void TextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if ((sender as TextBox).Text != "" && !int.TryParse((sender as TextBox).Text, out _))
-            {
-                (sender as TextBox).Text = "";
-                MessageBox.Show("Строка должна содержать только цифры!", "Ошибка");
-                return;
-            }
+            (sender as TextBox).Text = string.Join("", (sender as TextBox).Text.Where(c => char.IsDigit(c)));
+            (sender as TextBox).SelectionStart = (sender as TextBox).Text.Length;
 
             if ((sender as TextBox).Text == "" || Convert.ToInt32((sender as TextBox).Text) < 1900 || Convert.ToInt32((sender as TextBox).Text) > DateTime.Now.Year - 13)
             {


### PR DESCRIPTION
Описание бага подробно представлено [issue 78](https://github.com/Students-of-the-city-of-Kostroma/tournament-project/issues/78)

**Проблема:** Вылетает приложение в регистрации участников при вставке в параметр Год символов Кириллицы и Латиницы

**Решение:** Игнорирование всех символов, кроме числовых